### PR TITLE
Replace Spigot dependencies with Paper

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,7 +1,6 @@
 dependencies {
-    // Spigot API
-    compileOnly("org.spigotmc:spigot:1.21.8-R0.1-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.21.8-R0.1-SNAPSHOT")
+    // Paper API
+    compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
 
     compileOnly("net.kyori:adventure-api:4.24.0")
     compileOnly("net.kyori:adventure-text-minimessage:4.24.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,29 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.fabricmc.tinyremapper.NonClassCopyMode
+import net.fabricmc.tinyremapper.OutputConsumerPath
+import net.fabricmc.tinyremapper.TinyRemapper
+import net.fabricmc.tinyremapper.TinyUtils
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.RegularFileProperty
 import org.apache.tools.ant.filters.ReplaceTokens
-import java.net.URI
+import org.gradle.api.provider.Property
+import java.io.BufferedInputStream
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipInputStream
+
+buildscript {
+    repositories {
+        mavenCentral()
+        maven(url = "https://repo.papermc.io/repository/maven-public/")
+        maven(url = "https://maven.fabricmc.net/")
+    }
+    dependencies {
+        classpath("net.fabricmc:tiny-remapper:0.12.0")
+    }
+}
 
 plugins {
     java
@@ -52,6 +75,11 @@ tasks.named("jar") {
 repositories {
     mavenLocal()
     mavenCentral()
+    maven(url = "https://repo.papermc.io/repository/maven-public/") {
+        metadataSources {
+            artifact()
+        }
+    }
     maven(url = "https://jitpack.io")
 }
 
@@ -68,12 +96,12 @@ subprojects {
         mavenLocal()
         mavenCentral()
 
-        // Spigot
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
-        maven(url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
-
         // Paper
-        maven { url = uri("https://papermc.io/repo/maven-public/") }
+        maven(url = "https://repo.papermc.io/repository/maven-public/") {
+            metadataSources {
+                artifact()
+            }
+        }
 
         // Plugins
         maven(url = "https://jitpack.io")
@@ -90,125 +118,144 @@ subprojects {
             languageVersion.set(JavaLanguageVersion.of(javaVersion))
         })
     }
+
+    if (extensions.extraProperties.has("remapMinecraftVersion")) {
+        val mcVersion = extensions.extraProperties["remapMinecraftVersion"].toString()
+        val paperDevBundle by configurations.creating {
+            isCanBeConsumed = false
+            isCanBeResolved = true
+        }
+
+        dependencies {
+            add(paperDevBundle.name, "io.papermc.paper:dev-bundle:$mcVersion-R0.1-SNAPSHOT")
+        }
+
+        val mojangJarProvider = paperDevBundle.elements.map { elements ->
+            require(elements.size == 1) {
+                "Expected exactly one Paper dev bundle for project ${name}"
+            }
+            val bundleFile = elements.single().asFile
+            val extractedDir = ensurePaperDevBundleExtracted(layout.buildDirectory.get().asFile, mcVersion, bundleFile)
+            extractedDir.resolve("data/paperclip-mojang.jar")
+        }
+
+        dependencies {
+            add("compileOnly", project.files(mojangJarProvider))
+        }
+
+        extensions.extraProperties["paperDevBundleConfig"] = paperDevBundle
+    }
+
 }
 
 // Obfuscation Tasks
-abstract class VersionedObfTask @Inject constructor(
-    private val subproject: Project,
-    private val execOperations: ExecOperations
-) : DefaultTask() {
-
-    // Configure inputs and paths at configuration time
-    @get:Input
-    val minecraftVersion: String = subproject.property("remapMinecraftVersion") as String
+abstract class VersionedObfTask : DefaultTask() {
 
     @get:Input
-    val nmsName: String = subproject.name
-
-    @get:Input
-    val projectName: String = project.name
-
-    @get:Input
-    val projectVersion: String = project.version.toString()
-
-    @get:Internal
-    val homeDir: File = project.gradle.gradleUserHomeDir.parentFile
+    abstract val minecraftVersion: Property<String>
 
     @get:Internal
     val buildDir: File = project.layout.buildDirectory.get().asFile
 
+    @get:InputFile
+    abstract val devBundleZip: RegularFileProperty
+
     init {
         group = "jar preparation"
-        description = "Generates an obfuscated version of the jar to use with Spigot!"
+        description = "Generates an obfuscated version of the jar to use with Paper!"
         dependsOn("shadowJar")
-    }
-
-    private fun resolveSpecialSourceJar(): File {
-        val envDir = project.findProperty("SpecialSourcePath")?.toString()?.takeIf { it.isNotBlank() }
-            ?: System.getenv("SpecialSourcePath")?.takeIf { it.isNotBlank() }
-
-        val candidate = if (envDir != null) {
-            File(envDir, "SpecialSource.jar")
-        } else {
-            File(project.projectDir, "SpecialSource.jar")
-        }
-
-        // If found, use it
-        if (candidate.exists()) {
-            return candidate
-        }
-
-        // If not found, we download it to the project root
-        val downloadTarget = File(project.projectDir, "SpecialSource.jar")
-
-        if (!downloadTarget.exists()) {
-            val downloadUrl =
-                "https://repo1.maven.org/maven2/net/md-5/SpecialSource/1.11.5/SpecialSource-1.11.5-shaded.jar"
-
-            logger.lifecycle("SpecialSource.jar not found at ${candidate.absolutePath}")
-            logger.lifecycle("Downloading SpecialSource.jar from $downloadUrl to ${downloadTarget.absolutePath} ...")
-
-            // Make parent directory if needed
-            downloadTarget.parentFile?.let { if (!it.exists()) it.mkdirs() }
-
-            // Download
-            URI(downloadUrl).toURL().openStream().use { input ->
-                downloadTarget.outputStream().use { output ->
-                    input.copyTo(output)
-                }
-            }
-            logger.lifecycle("Downloaded SpecialSource.jar to ${downloadTarget.absolutePath}")
-        }
-        return downloadTarget
     }
 
     @TaskAction
     fun obfuscate() {
-        val specialSourceFile = resolveSpecialSourceJar()
-
         val libsDir = "$buildDir/libs"
-        val inputJar = "$libsDir/$projectName-$projectVersion.jar"
-        val obfJar = "$libsDir/$projectName-$projectVersion-obf.jar"
+        val projectName = project.name
+        val projectVersion = project.version.toString()
+        val inputJar = Path.of(libsDir, "$projectName-$projectVersion.jar")
+        val obfJar = Path.of(libsDir, "$projectName-$projectVersion-obf.jar")
 
-        // Validate required files exist
-        require(specialSourceFile.exists()) {
-            "SpecialSource.jar not found at ${specialSourceFile.absolutePath}"
+        val extractedBundleDir = ensurePaperDevBundleExtracted(buildDir, minecraftVersion.get(), devBundleZip.asFile.get())
+        val mappingFile = extractedBundleDir.resolve("data/mojang-spigot-reobf.tiny")
+        val mojangJar = extractedBundleDir.resolve("data/paperclip-mojang.jar")
+
+        require(mappingFile.exists()) {
+            "Could not find Paper mapping file at ${mappingFile.absolutePath}"
+        }
+        require(mojangJar.exists()) {
+            "Could not find Paper mojang-mapped jar at ${mojangJar.absolutePath}"
         }
 
-        val mojangMap =
-            "$homeDir/.m2/repository/org/spigotmc/minecraft-server/$minecraftVersion-R0.1-SNAPSHOT/minecraft-server-$minecraftVersion-R0.1-SNAPSHOT-maps-mojang.txt"
-        val spigotMap =
-            "$homeDir/.m2/repository/org/spigotmc/minecraft-server/$minecraftVersion-R0.1-SNAPSHOT/minecraft-server-$minecraftVersion-R0.1-SNAPSHOT-maps-spigot.csrg"
-        val mojangRemap =
-            "$homeDir/.m2/repository/org/spigotmc/spigot/$minecraftVersion-R0.1-SNAPSHOT/spigot-$minecraftVersion-R0.1-SNAPSHOT-remapped-mojang.jar"
-        val obfuscationRemap =
-            "$homeDir/.m2/repository/org/spigotmc/spigot/$minecraftVersion-R0.1-SNAPSHOT/spigot-$minecraftVersion-R0.1-SNAPSHOT-remapped-obf.jar"
+        Files.deleteIfExists(obfJar)
 
-        // First pass: mojang -> obf
-        execOperations.exec {
-            workingDir(buildDir)
-            commandLine(
-                "java", "-cp", "$specialSourceFile${File.pathSeparator}$mojangRemap",
-                "net.md_5.specialsource.SpecialSource", "--live", "--only", "se/file14/procosmetics/$nmsName", "-q",
-                "-i", inputJar, "-o", obfJar, "-m", mojangMap, "--reverse"
-            )
+        val remapper = TinyRemapper.newRemapper()
+            .withMappings(TinyUtils.createTinyMappingProvider(mappingFile.toPath(), "mojang", "spigot"))
+            .ignoreConflicts(true)
+            .rebuildSourceFilenames(true)
+            .build()
+
+        try {
+            remapper.readClassPath(mojangJar.toPath())
+            remapper.readInputs(inputJar)
+
+            OutputConsumerPath.Builder(obfJar).build().use { outputConsumer ->
+                outputConsumer.addNonClassFiles(inputJar, NonClassCopyMode.FIX_META_INF, remapper)
+                remapper.apply(outputConsumer)
+            }
+        } finally {
+            remapper.finish()
         }
 
-        // Second pass: obf -> spigot
-        execOperations.exec {
-            workingDir(buildDir)
-            commandLine(
-                "java", "-cp", "$specialSourceFile${File.pathSeparator}$obfuscationRemap",
-                "net.md_5.specialsource.SpecialSource", "--live", "--only", "se/file14/procosmetics/$nmsName", "-q",
-                "-i", obfJar, "-o", inputJar, "-m", spigotMap
-            )
-        }
+        Files.move(obfJar, inputJar, StandardCopyOption.REPLACE_EXISTING)
     }
+
 }
 
-subprojects.forEach {
-    if (it.extra.has("remapMinecraftVersion")) {
-        tasks.register("obf${it.name.replaceFirstChar { char -> char.uppercaseChar() }}", VersionedObfTask::class, it)
+private fun ensurePaperDevBundleExtracted(buildDir: File, minecraftVersion: String, bundleFile: File): File {
+    val targetDir = File(buildDir, "paper-dev-bundles/$minecraftVersion")
+    val mappingFile = File(targetDir, "data/mojang-spigot-reobf.tiny")
+
+    if (mappingFile.exists() && mappingFile.lastModified() >= bundleFile.lastModified()) {
+        return targetDir
+    }
+
+    if (targetDir.exists()) {
+        targetDir.deleteRecursively()
+    }
+    targetDir.mkdirs()
+
+    ZipInputStream(BufferedInputStream(bundleFile.inputStream())).use { zip ->
+        var entry = zip.nextEntry
+        while (entry != null) {
+            if (!entry.isDirectory && (entry.name == "data/mojang-spigot-reobf.tiny" || entry.name == "data/paperclip-mojang.jar")) {
+                val outputFile = File(targetDir, entry.name)
+                outputFile.parentFile?.mkdirs()
+                outputFile.outputStream().use { out ->
+                    zip.copyTo(out)
+                }
+            }
+            entry = zip.nextEntry
+        }
+    }
+
+    return targetDir
+}
+
+subprojects.forEach { subproject ->
+    if (subproject.extensions.extraProperties.has("paperDevBundleConfig") &&
+        subproject.extensions.extraProperties.has("remapMinecraftVersion")) {
+        val devBundleConfig = subproject.extensions.extraProperties["paperDevBundleConfig"] as Configuration
+        val devBundleFileProvider = devBundleConfig.elements.map { elements ->
+            require(elements.size == 1) {
+                "Expected exactly one Paper dev bundle for project ${subproject.name}"
+            }
+            project.objects.fileProperty().fileValue(elements.single().asFile).get()
+        }
+
+        tasks.register<VersionedObfTask>("obf${subproject.name.replaceFirstChar { char -> char.uppercaseChar() }}") {
+            dependsOn("shadowJar")
+            minecraftVersion.set(subproject.extensions.extraProperties["remapMinecraftVersion"].toString())
+            devBundleZip.set(devBundleFileProvider)
+        }
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,7 +1,6 @@
 dependencies {
-    // Spigot API
-    compileOnly("org.spigotmc:spigot:1.21.8-R0.1-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.21.8-R0.1-SNAPSHOT")
+    // Paper API
+    compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
 
     // Project dependencies
     implementation(project(":api"))

--- a/v1_20/build.gradle.kts
+++ b/v1_20/build.gradle.kts
@@ -1,6 +1,4 @@
 dependencies {
-    compileOnly("org.spigotmc:spigot:1.20.6-R0.1-SNAPSHOT:remapped-mojang")
-
     compileOnly("net.kyori:adventure-api:4.24.0")
     compileOnly("net.kyori:adventure-platform-bukkit:4.4.1")
 

--- a/v1_21/build.gradle.kts
+++ b/v1_21/build.gradle.kts
@@ -1,6 +1,4 @@
 dependencies {
-    compileOnly("org.spigotmc:spigot:1.21.8-R0.1-SNAPSHOT:remapped-mojang")
-
     compileOnly("net.kyori:adventure-api:4.24.0")
     compileOnly("net.kyori:adventure-platform-bukkit:4.4.1")
 


### PR DESCRIPTION
## Summary
- replace spigot compileOnly dependencies with Paper API across the build scripts
- download and extract Paper dev bundles to supply Mojang-mapped jars for compilation and remapping
- update the obfuscation task to remap using tiny-remapper and Paper mappings instead of SpecialSource/Spigot artifacts

## Testing
- bash ./gradlew help

------
https://chatgpt.com/codex/tasks/task_e_68e3082546b48332822fdbf5e6a590ce