### PR TITLE
Fix Paper dev bundle handling for versioned modules

### DIFF
--- a/buildSrc/src/main/kotlin/se/file14/procosmetics/gradle/VersionedObfTask.kt
+++ b/buildSrc/src/main/kotlin/se/file14/procosmetics/gradle/VersionedObfTask.kt
@@ -13,9 +13,10 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import java.io.BufferedInputStream
 import java.io.File
+import java.net.URI
 import java.nio.file.Files
-import java.nio.file.Path
 import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
 import java.util.zip.ZipInputStream
 
 abstract class VersionedObfTask : DefaultTask() {
@@ -27,8 +28,12 @@ abstract class VersionedObfTask : DefaultTask() {
     abstract val devBundleZip: RegularFileProperty
 
     @get:Internal
-    protected val buildDir: File
+    protected val buildDirFile: File
         get() = project.layout.buildDirectory.get().asFile
+
+    @get:Internal
+    val bundleCacheDir: File
+        get() = project.rootProject.layout.projectDirectory.dir(".gradle/paper-dev-bundles").asFile
 
     init {
         group = "jar preparation"
@@ -38,15 +43,16 @@ abstract class VersionedObfTask : DefaultTask() {
 
     @TaskAction
     fun obfuscate() {
-        val libsDir = "$buildDir/libs"
+        val libsDir = buildDirFile.toPath().resolve("libs")
         val projectName = project.name
         val projectVersion = project.version.toString()
-        val inputJar = Path.of(libsDir, "$projectName-$projectVersion.jar")
-        val obfJar = Path.of(libsDir, "$projectName-$projectVersion-obf.jar")
+        val inputJar = libsDir.resolve("$projectName-$projectVersion.jar")
+        val obfJar = libsDir.resolve("$projectName-$projectVersion-obf.jar")
 
-        val extractedBundleDir = ensurePaperDevBundleExtracted(buildDir, minecraftVersion.get(), devBundleZip.asFile.get())
+        val extractedBundleDir = ensurePaperDevBundleExtracted(bundleCacheDir, minecraftVersion.get(), devBundleZip.asFile.get())
         val mappingFile = extractedBundleDir.resolve("data/mojang-spigot-reobf.tiny")
-        val mojangJar = extractedBundleDir.resolve("data/paperclip-mojang.jar")
+        val resources = ensurePaperDevBundleResources(extractedBundleDir, minecraftVersion.get())
+        val mojangJar = resources.mojangJar
 
         require(mappingFile.exists()) {
             "Could not find Paper mapping file at ${mappingFile.absolutePath}"
@@ -57,8 +63,10 @@ abstract class VersionedObfTask : DefaultTask() {
 
         Files.deleteIfExists(obfJar)
 
+        val sourceNamespace = detectSourceNamespace(mappingFile)
+
         val remapper = TinyRemapper.newRemapper()
-            .withMappings(TinyUtils.createTinyMappingProvider(mappingFile.toPath(), "mojang", "spigot"))
+            .withMappings(TinyUtils.createTinyMappingProvider(mappingFile.toPath(), sourceNamespace, "spigot"))
             .ignoreConflicts(true)
             .rebuildSourceFilenames(true)
             .build()
@@ -79,8 +87,8 @@ abstract class VersionedObfTask : DefaultTask() {
     }
 }
 
-fun ensurePaperDevBundleExtracted(buildDir: File, minecraftVersion: String, bundleFile: File): File {
-    val targetDir = File(buildDir, "paper-dev-bundles/$minecraftVersion")
+fun ensurePaperDevBundleExtracted(cacheRoot: File, minecraftVersion: String, bundleFile: File): File {
+    val targetDir = File(cacheRoot, minecraftVersion)
     val mappingFile = File(targetDir, "data/mojang-spigot-reobf.tiny")
 
     if (mappingFile.exists() && mappingFile.lastModified() >= bundleFile.lastModified()) {
@@ -95,11 +103,19 @@ fun ensurePaperDevBundleExtracted(buildDir: File, minecraftVersion: String, bund
     ZipInputStream(BufferedInputStream(bundleFile.inputStream())).use { zip ->
         var entry = zip.nextEntry
         while (entry != null) {
-            if (!entry.isDirectory && (entry.name == "data/mojang-spigot-reobf.tiny" || entry.name == "data/paperclip-mojang.jar")) {
-                val outputFile = File(targetDir, entry.name)
-                outputFile.parentFile?.mkdirs()
-                outputFile.outputStream().use { out ->
-                    zip.copyTo(out)
+            if (!entry.isDirectory) {
+                val targetName = when {
+                    entry.name == "data/mojang-spigot-reobf.tiny" || entry.name == "data/mojang+yarn-spigot-reobf.tiny" -> "data/mojang-spigot-reobf.tiny"
+                    entry.name == "data/paperclip-mojang.jar" || entry.name == "data/paperclip-mojang+yarn.jar" -> "data/paperclip-mojang.jar"
+                    else -> null
+                }
+
+                if (targetName != null) {
+                    val outputFile = File(targetDir, targetName)
+                    outputFile.parentFile?.mkdirs()
+                    outputFile.outputStream().use { out ->
+                        zip.copyTo(out)
+                    }
                 }
             }
             entry = zip.nextEntry
@@ -107,4 +123,119 @@ fun ensurePaperDevBundleExtracted(buildDir: File, minecraftVersion: String, bund
     }
 
     return targetDir
+}
+
+data class PaperclipResources(val mojangJar: File, val patchedJar: File)
+
+fun ensurePaperDevBundleResources(bundleDir: File, minecraftVersion: String): PaperclipResources {
+    val paperclipJar = File(bundleDir, "data/paperclip-mojang.jar")
+    require(paperclipJar.exists()) {
+        "Could not find Paperclip jar at ${paperclipJar.absolutePath}"
+    }
+
+    val downloadContexts = readDownloadContexts(paperclipJar)
+    val cacheDir = File(bundleDir, "cache")
+    cacheDir.mkdirs()
+
+    var mojangJar: File? = null
+
+    downloadContexts.forEach { context ->
+        val target = File(cacheDir, context.fileName)
+        ensureFileWithHash(context.url, context.sha256, target)
+        if (context.fileName.startsWith("mojang_")) {
+            mojangJar = target
+        }
+    }
+
+    val resolvedMojangJar = mojangJar
+        ?: error("Could not determine Mojang server jar from Paperclip download context")
+
+    val patchedJar = File(bundleDir, "versions/$minecraftVersion/paper-$minecraftVersion.jar")
+    if (!patchedJar.exists()) {
+        runPaperclipBuild(paperclipJar, bundleDir)
+        require(patchedJar.exists()) {
+            "Paperclip did not produce patched jar at ${patchedJar.absolutePath}"
+        }
+    }
+
+    return PaperclipResources(resolvedMojangJar, patchedJar)
+}
+
+private data class DownloadContext(val sha256: String, val url: String, val fileName: String)
+
+private fun readDownloadContexts(paperclipJar: File): List<DownloadContext> {
+    return java.util.jar.JarFile(paperclipJar).use { jar ->
+        val entry = jar.getJarEntry("META-INF/download-context")
+            ?: return emptyList()
+        jar.getInputStream(entry).use { input ->
+            input.bufferedReader().readLines()
+                .mapNotNull { line ->
+                    val trimmed = line.trim()
+                    if (trimmed.isEmpty()) return@mapNotNull null
+                    val parts = trimmed.split(Regex("\\s+"))
+                    require(parts.size == 3) { "Invalid download-context line: $trimmed" }
+                    DownloadContext(parts[0], parts[1], parts[2])
+                }
+        }
+    }
+}
+
+private fun ensureFileWithHash(url: String, expectedSha256: String, target: File) {
+    if (target.exists() && target.isFile) {
+        val actual = sha256(target)
+        if (actual.equals(expectedSha256, ignoreCase = true)) {
+            return
+        }
+    }
+
+    target.parentFile?.mkdirs()
+    URI.create(url).toURL().openStream().use { input ->
+        target.outputStream().use { out ->
+            input.copyTo(out)
+        }
+    }
+
+    val actual = sha256(target)
+    require(actual.equals(expectedSha256, ignoreCase = true)) {
+        "Checksum mismatch for ${target.absolutePath}. Expected $expectedSha256 but found $actual"
+    }
+}
+
+private fun sha256(file: File): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { input ->
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = input.read(buffer)
+            if (read == -1) break
+            digest.update(buffer, 0, read)
+        }
+    }
+    return digest.digest().joinToString(separator = "") { byte ->
+        val value = byte.toInt() and 0xFF
+        value.toString(16).padStart(2, '0')
+    }
+}
+
+private fun runPaperclipBuild(paperclipJar: File, workingDir: File) {
+    val javaHome = System.getProperty("java.home")
+    val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+    val javaExecutable = File(javaHome, "bin/${if (isWindows) "java.exe" else "java"}")
+    val process = ProcessBuilder(javaExecutable.absolutePath, "-jar", paperclipJar.absolutePath, "--build")
+        .directory(workingDir)
+        .inheritIO()
+        .start()
+    process.waitFor()
+}
+
+private fun detectSourceNamespace(mappingFile: File): String {
+    mappingFile.bufferedReader().use { reader ->
+        val header = reader.readLine()?.trim()
+            ?: error("Mapping file ${mappingFile.absolutePath} is empty")
+        val parts = header.split('\t')
+        require(parts.size >= 5 && parts[0] == "tiny") {
+            "Unexpected tiny mapping header in ${mappingFile.absolutePath}: $header"
+        }
+        return parts[3]
+    }
 }


### PR DESCRIPTION
## Summary
- ensure versioned subprojects resolve the Paper dev bundle zip and add the Mojang and patched Paper jars to their compile classpaths
- enhance the versioned obfuscation task to cache and reuse extracted Paper dev bundle resources when remapping jars

## Testing
- ./gradlew clean build

------
https://chatgpt.com/codex/tasks/task_e_68e4193ee8c08332be12e2ad843df2ee