### PR TITLE
Shade Folia-ready NoteBlockAPI fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ Folia-compliant.
 
 #### Shading your Folia-ready NoteBlockAPI fork
 
-1. Build your fork and copy the resulting jar into `libs/NoteBlockAPI-folia.jar` in the repository root (create the
+1. Build your fork and copy the resulting jar into `libs/NoteBlockAPI-1.6.4-SNAPSHOT.jar` in the repository root (create the
    `libs` directory if it does not exist). Keeping the jar in a shared location lets both the Gradle and Maven builds
    reference the same artifact.
 2. Update the Gradle dependencies so every module resolves against the local jar:
    - In `api/build.gradle.kts`, replace the existing NoteBlockAPI `compileOnly` entry with
      ```kotlin
-     compileOnly(files(rootProject.file("libs/NoteBlockAPI-folia.jar")))
+     compileOnly(files(rootProject.file("libs/NoteBlockAPI-1.6.4-SNAPSHOT.jar")))
      ```
    - In `core/build.gradle.kts`, replace the NoteBlockAPI `implementation` entry with
      ```kotlin
-     implementation(files(rootProject.file("libs/NoteBlockAPI-folia.jar")))
+     implementation(files(rootProject.file("libs/NoteBlockAPI-1.6.4-SNAPSHOT.jar")))
      ```
    These statements keep the jar shaded into the final plugin artifact, just like the current remote dependency.
 3. If you use the Maven build, install the jar into your local Maven repository so the `api` and `core` modules can pull
    it in:
    ```bash
-   mvn install:install-file \ 
-     -Dfile=libs/NoteBlockAPI-folia.jar \ 
-     -DgroupId=se.file14.folia \ 
-     -DartifactId=NoteBlockAPI \ 
-     -Dversion=1.6.5-folia \ 
+   mvn install:install-file \
+     -Dfile=libs/NoteBlockAPI-1.6.4-SNAPSHOT.jar \
+     -DgroupId=se.file14.folia \
+     -DartifactId=NoteBlockAPI \
+     -Dversion=1.6.4-SNAPSHOT \
      -Dpackaging=jar
    ```
-   Afterwards, update both `api/pom.xml` and `core/pom.xml` to depend on `se.file14.folia:NoteBlockAPI:1.6.5-folia`
+   Afterwards, update both `api/pom.xml` and `core/pom.xml` to depend on `se.file14.folia:NoteBlockAPI:1.6.4-SNAPSHOT`
    instead of the temporary JitPack coordinate.
 
 ## License

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
     compileOnly("org.jetbrains:annotations:26.0.2")
 
     //compileOnly("com.github.koca2000:NoteBlockAPI:1.6.3") // temporarily disabled
-    compileOnly("com.github.ashtton:NoteBlockAPI:78f2966ccd")
+    compileOnly(files(rootProject.file("libs/NoteBlockAPI-1.6.4-SNAPSHOT.jar")))
 }

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -45,9 +45,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.ashtton</groupId>
+            <groupId>se.file14.folia</groupId>
             <artifactId>NoteBlockAPI</artifactId>
-            <version>78f2966ccd</version>
+            <version>1.6.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 
     // Runtime libraries (will be shaded)
     //implementation("com.github.koca2000:NoteBlockAPI:1.6.3") temporarily disabled
-    implementation("com.github.ashtton:NoteBlockAPI:78f2966ccd")
+    implementation(files(rootProject.file("libs/NoteBlockAPI-1.6.4-SNAPSHOT.jar")))
     implementation("com.zaxxer:HikariCP:7.0.2")
     implementation("org.xerial:sqlite-jdbc:3.50.3.0")
     implementation("org.bstats:bstats-bukkit:3.1.0")

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,9 +34,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.ashtton</groupId>
+            <groupId>se.file14.folia</groupId>
             <artifactId>NoteBlockAPI</artifactId>
-            <version>78f2966ccd</version>
+            <version>1.6.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
## Summary
- update Gradle modules to resolve NoteBlockAPI from the bundled Folia-ready jar
- align Maven modules and README instructions with the local NoteBlockAPI 1.6.4-SNAPSHOT artifact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43d38bc548332989c8de00062adc3