### PR TITLE
Ensure shaded jar retains ProCosmetics plugin metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.api.file.DuplicatesStrategy
 import java.io.File
 import se.file14.procosmetics.gradle.VersionedObfTask
 import se.file14.procosmetics.gradle.ensurePaperDevBundleExtracted
@@ -37,6 +38,10 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.processResources {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    from(layout.projectDirectory.dir("plugin/src/main/resources"))
+
     val projectVersion = project.version
     inputs.property("version", projectVersion)
     filesMatching("**/plugin.yml") {
@@ -47,6 +52,7 @@ tasks.processResources {
 // Configure shadow jar
 tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     // Exclude unnecessary files
     exclude("META-INF/maven/**")


### PR DESCRIPTION
## Summary
- include the plugin module resources in the Gradle build so the shaded jar bundles the descriptor and configs
- prevent shaded dependencies from overwriting plugin.yml by excluding duplicates when producing the shadow jar

## Testing
- ./gradlew clean build

------
https://chatgpt.com/codex/tasks/task_e_68e443e936208332912274d55d2bdf36