### PR TITLE
Improve NoteBlockAPI bootstrap and avoid unnecessary reobf

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.api.file.DuplicatesStrategy
 import java.io.File
 import se.file14.procosmetics.gradle.VersionedObfTask
 import se.file14.procosmetics.gradle.ensurePaperDevBundleExtracted
@@ -37,6 +38,10 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.processResources {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    from(layout.projectDirectory.dir("plugin/src/main/resources"))
+
     val projectVersion = project.version
     inputs.property("version", projectVersion)
     filesMatching("**/plugin.yml") {
@@ -47,6 +52,7 @@ tasks.processResources {
 // Configure shadow jar
 tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     // Exclude unnecessary files
     exclude("META-INF/maven/**")
@@ -164,6 +170,10 @@ subprojects {
 subprojects.forEach { subproject ->
     if (subproject.extensions.extraProperties.has("paperDevBundleConfig") &&
         subproject.extensions.extraProperties.has("remapMinecraftVersion")) {
+        val enableSpigotRemap = subproject.findProperty("enableSpigotRemap")?.toString()?.toBoolean() ?: true
+        if (!enableSpigotRemap) {
+            return@forEach
+        }
         val devBundleConfig = subproject.extensions.extraProperties["paperDevBundleConfig"] as Configuration
         val devBundleFileProvider = devBundleConfig.elements.map { elements ->
             require(elements.size == 1) {

--- a/core/src/main/java/se/file14/procosmetics/ProCosmeticsPlugin.java
+++ b/core/src/main/java/se/file14/procosmetics/ProCosmeticsPlugin.java
@@ -7,6 +7,7 @@ import org.bstats.charts.SimplePie;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -79,12 +80,14 @@ public class ProCosmeticsPlugin extends JavaPlugin implements ProCosmetics {
     private boolean disabling;
 
     private CategoryRegistries categoryRegistries;
+    private boolean selfInitializedNoteBlockApi;
 
     @Override
     public void onLoad() {
         ProCosmeticsPlugin.plugin = this;
         logger = getLogger();
         disabling = false;
+        selfInitializedNoteBlockApi = false;
 
         if (!VersionUtil.isSupported()) {
             LogUtil.printUnsupported();
@@ -104,11 +107,11 @@ public class ProCosmeticsPlugin extends JavaPlugin implements ProCosmetics {
         fakeBlockManager = new FakeBlockManager(this);
         economyManager = new EconomyManagerImpl(this);
         placeholderManager = new PlaceholderManager(this);
-        commandBase = new CommandBase(this);
 
         logger.info("Initializing cosmetics...");
         CosmeticRarityRegistry.load();
         categoryRegistries = new CategoryRegistriesImpl(this);
+        commandBase = new CommandBase(this);
 
         initializeDatabase();
         initializeMetrics();
@@ -203,20 +206,40 @@ public class ProCosmeticsPlugin extends JavaPlugin implements ProCosmetics {
     }
 
     private void initializeNoteBlockAPI() {
+        if (NoteBlockAPI.getAPI() != null) {
+            return;
+        }
+        PluginManager pluginManager = getServer().getPluginManager();
+        Plugin provided = pluginManager.getPlugin("NoteBlockAPI");
+        if (provided != null) {
+            if (!provided.isEnabled()) {
+                pluginManager.enablePlugin(provided);
+            }
+            if (NoteBlockAPI.getAPI() != null) {
+                return;
+            }
+        }
+
         if (tryInvokeStatic(NoteBlockAPI.class, "initializeAPI")) {
+            selfInitializedNoteBlockApi = true;
             return;
         }
         if (tryInvokeStatic(NoteBlockAPI.class, "initializeAPI", new Class<?>[]{JavaPlugin.class}, this)) {
+            selfInitializedNoteBlockApi = true;
             return;
         }
         if (tryInvokeStatic(NoteBlockAPI.class, "initialize", new Class<?>[]{JavaPlugin.class}, this)) {
+            selfInitializedNoteBlockApi = true;
             return;
         }
 
-        logger.warning("Unable to locate a compatible NoteBlockAPI initialization method; continuing without explicit init.");
+        logger.warning("Unable to locate a compatible NoteBlockAPI initialization method; NoteBlockAPI must be installed as a plugin or expose initializeAPI.");
     }
 
     private void shutdownNoteBlockAPI() {
+        if (!selfInitializedNoteBlockApi) {
+            return;
+        }
         Object api = NoteBlockAPI.getAPI();
         if (api == null) {
             return;

--- a/v1_21/gradle.properties
+++ b/v1_21/gradle.properties
@@ -1,2 +1,3 @@
 javaVersion=21
 remapMinecraftVersion=1.21.8
+enableSpigotRemap=false


### PR DESCRIPTION
## Summary
- guard the NoteBlockAPI bootstrap against externally provided plugins and only invoke legacy initializers when necessary
- allow individual modules to disable spigot reobfuscation and turn it off for the 1.21 build so the jar keeps Mojang names on Folia

## Testing
- ./gradlew clean build

------
https://chatgpt.com/codex/tasks/task_e_68e443e936208332912274d55d2bdf36