### PR TITLE
Fix mapping detection for Folia compatibility

### DIFF
--- a/core/src/main/java/se/file14/procosmetics/util/mapping/Mapping.java
+++ b/core/src/main/java/se/file14/procosmetics/util/mapping/Mapping.java
@@ -8,15 +8,31 @@ public class Mapping {
     public static MappingType MAPPING_TYPE = MappingType.SPIGOT;
 
     static {
-        try {
-            // Check if the server is running Paper
-            Class.forName("com.destroystokyo.paper.ParticleBuilder");
+        boolean useMojangMappings = false;
 
-            // Starting from 1.20.6 Paper uses Mojang mappings
+        try {
+            // Check if the server is running Paper. Starting from 1.20.6 Paper uses Mojang mappings.
+            Class.forName("com.destroystokyo.paper.ParticleBuilder");
             if (VersionUtil.isHigherThanOrEqualTo(BukkitVersion.v1_20)) {
-                MAPPING_TYPE = MappingType.MOJANG;
+                useMojangMappings = true;
             }
         } catch (ClassNotFoundException ignored) {
+            // Folia does not include this class, fall back to an additional check below.
+        }
+
+        if (!useMojangMappings) {
+            try {
+                // Folia and other Mojang-mapped forks expose unversioned CraftBukkit classes.
+                Class.forName("org.bukkit.craftbukkit.entity.CraftPlayer");
+                if (VersionUtil.isHigherThanOrEqualTo(BukkitVersion.v1_20)) {
+                    useMojangMappings = true;
+                }
+            } catch (ClassNotFoundException ignored) {
+            }
+        }
+
+        if (useMojangMappings) {
+            MAPPING_TYPE = MappingType.MOJANG;
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure Mojang mappings are selected when Folia exposes unversioned CraftBukkit classes
- fall back to Paper detection while gracefully handling Folia's missing ParticleBuilder class

## Testing
- ./gradlew :core:build

------
https://chatgpt.com/codex/tasks/task_e_68e45d897340833290be2b4b710b0ba9