### PR TITLE
Fix 1.21 NMS world handle lookups

### DIFF
--- a/v1_21/src/main/java/se/file14/procosmetics/v1_21/NMSEntity.java
+++ b/v1_21/src/main/java/se/file14/procosmetics/v1_21/NMSEntity.java
@@ -31,7 +31,6 @@ import org.bukkit.Input;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -41,8 +40,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 import se.file14.procosmetics.api.nms.EntityTracker;
-import se.file14.procosmetics.nms.NMSEntityImpl;
 import se.file14.procosmetics.nms.entitytype.CachedEntityType;
+import se.file14.procosmetics.nms.NMSEntityImpl;
+import se.file14.procosmetics.util.ReflectionUtil;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -65,7 +65,7 @@ public class NMSEntity extends NMSEntityImpl {
 
     public NMSEntity(World world, CachedEntityType cachedEntityType, EntityTracker tracker) {
         super(world, cachedEntityType, tracker);
-        entity = ((net.minecraft.world.entity.EntityType<?>) cachedEntityType.getEntityTypeObject()).create(((CraftWorld) world).getHandle(), EntitySpawnReason.COMMAND);
+        entity = ((net.minecraft.world.entity.EntityType<?>) cachedEntityType.getEntityTypeObject()).create((Level) ReflectionUtil.getHandle(world), EntitySpawnReason.COMMAND);
     }
 
     public NMSEntity(World world, BlockData blockData, EntityTracker tracker) {
@@ -76,7 +76,7 @@ public class NMSEntity extends NMSEntityImpl {
                 fallingBlockConstructor = FallingBlockEntity.class.getDeclaredConstructor(Level.class, double.class, double.class, double.class, BlockState.class);
                 fallingBlockConstructor.setAccessible(true);
             }
-            entity = fallingBlockConstructor.newInstance(((CraftWorld) world).getHandle(), 0.0d, 0.0d, 0.0d, ((CraftBlockData) blockData).getState());
+            entity = fallingBlockConstructor.newInstance((Level) ReflectionUtil.getHandle(world), 0.0d, 0.0d, 0.0d, ((CraftBlockData) blockData).getState());
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
                  InvocationTargetException e) {
             e.printStackTrace();

--- a/v1_21/src/main/java/se/file14/procosmetics/v1_21/NMSUtil.java
+++ b/v1_21/src/main/java/se/file14/procosmetics/v1_21/NMSUtil.java
@@ -7,11 +7,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.Connection;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import se.file14.procosmetics.nms.NMSUtilImpl;
@@ -59,7 +59,7 @@ public class NMSUtil extends NMSUtilImpl {
         Location location = block.getLocation();
         BlockPos blockPos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
 
-        ((CraftWorld) location.getWorld()).getHandle().blockEvent(blockPos,
+        ((Level) ReflectionUtil.getHandle(location.getWorld())).blockEvent(blockPos,
                 block.getType() == Material.CHEST ? Blocks.CHEST : Blocks.ENDER_CHEST,
                 1,
                 open ? 1 : 0


### PR DESCRIPTION
## Summary
- replace direct CraftWorld references in the 1.21 NMS entity classes with ReflectionUtil lookups
- ensure block events and entity creation use the reflected world handle to avoid version-specific classes

## Testing
- ./gradlew :v1_21:build

------
https://chatgpt.com/codex/tasks/task_e_68e547132dc483329f7ab2ff2305e71c